### PR TITLE
Run marquised in same fashion as vaultaire daemons

### DIFF
--- a/src/MarquiseDaemon.hs
+++ b/src/MarquiseDaemon.hs
@@ -13,6 +13,7 @@
 
 module Main where
 
+import Control.Concurrent.MVar
 import qualified Data.ByteString.Char8 as S
 import Data.Monoid
 import Options.Applicative hiding (Parser, option)
@@ -80,5 +81,8 @@ main = do
 
     quit <- initializeProgram (package ++ "-" ++ version) level
 
-    debugM "Main.main" "Starting marquise daemon"
-    marquiseServer broker origin namespace quit
+    runMarquiseDaemon broker origin namespace quit
+
+    -- wait forever
+    readMVar quit
+    debugM "Main.main" "End"


### PR DESCRIPTION
Largely cosmetic change; brings marquised into alignment with the way components are run in **vaultaire**'s vault binary, running the main workload in a thread and having the main thread blocking on an MVar.

Vaultaire no longer has a wrapper around running a Marquise.Server, leaving that to the marquised binary in this package.
