### PR TITLE
Ensure daemon thread stays alive

### DIFF
--- a/lib/Marquise/Server.hs
+++ b/lib/Marquise/Server.hs
@@ -54,7 +54,7 @@ runMarquiseDaemon broker origin namespace shutdown = do
     async $ startMarquise broker origin namespace shutdown
 
 startMarquise :: String -> Origin -> String -> MVar () -> IO ()
-startMarquise broker origin name _ = do
+startMarquise broker origin name shutdown = do
     infoM "Server.startMarquise" "Marquise daemon started"
     case makeSpoolName name of
         Left e -> throwIO e
@@ -65,6 +65,7 @@ startMarquise broker origin name _ = do
             linkThread (sendPoints broker origin sn)
             debugM "Server.startMarquise" "Starting contents transmitting thread"
             linkThread (sendContents broker origin sn)
+    readMVar shutdown
 
 sendPoints :: String -> Origin -> SpoolName -> IO ()
 sendPoints broker origin sn = forever $ do

--- a/marquise.cabal
+++ b/marquise.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                marquise
-version:             2.5.0
+version:             2.5.1
 synopsis:            Client library for Vaultaire
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>


### PR DESCRIPTION
Echos changes made to **vaultaire**'s Broker thread, with the same
solution: have the thing that has spawned off the worker threads then
wait on the shutdown MVar. @fractalcat 
