### PR TITLE
Added minimum version to pipes-attoparsec dependency.

### DIFF
--- a/marquise.cabal
+++ b/marquise.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                marquise
-version:             2.8.1
+version:             2.8.2
 synopsis:            Client library for Vaultaire
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>
@@ -46,7 +46,7 @@ library
                      pipes,
                      pipes-group,
                      pipes-bytestring,
-                     pipes-attoparsec,
+                     pipes-attoparsec >= 0.5,
                      siphash,
                      async,
                      hslogger,


### PR DESCRIPTION
This is to help ensure that when marquise is a dependency, cabal
does not install a lower version and fail to build, especially
for travis builds
