### PR TITLE
Expose marquise types in client

### DIFF
--- a/lib/Marquise/Client.hs
+++ b/lib/Marquise/Client.hs
@@ -49,6 +49,13 @@ module Marquise.Client (
     , SimplePoint(..)
     , SocketState(..)
     , Policy(..)
+
+    -- * Marquise top-level
+    , Marquise
+    , MarquiseErrorType(..)
+    , withMarquiseHandler
+    , catchMarquiseP
+    , unMarquise, unMarquise'
     ) where
 
 import           Control.Monad.Error hiding (forever)

--- a/marquise.cabal
+++ b/marquise.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                marquise
-version:             3.0.1
+version:             3.0.2
 synopsis:            Client library for Vaultaire
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>


### PR DESCRIPTION
 for users who don't import marquise.types
