### PR TITLE
Move simple/ext points to vaultaire-common

### DIFF
--- a/lib/Marquise/Types.hs
+++ b/lib/Marquise/Types.hs
@@ -97,31 +97,6 @@ data SpoolFiles = SpoolFiles { pointsSpoolFile   :: FilePath
                              , contentsSpoolFile :: FilePath }
   deriving (Eq, Show)
 
--- | SimplePoints are simply wrapped packets for Vaultaire
--- Each consists of 24 bytes:
--- An 8 byte Address
--- An 8 byte Timestamp (nanoseconds since Unix epoch)
--- An 8 byte Payload
-data SimplePoint = SimplePoint { simpleAddress :: Address
-                               , simpleTime    :: TimeStamp
-                               , simplePayload :: Word64 }
-  deriving (Show, Eq)
-
-
--- | ExtendedPoints are simply wrapped packets for Vaultaire
--- Each consists of 16 + 'length' bytes:
--- An 8 byte Address
--- An 8 byte Time (in nanoseconds since Unix epoch)
--- A 'length' byte Payload
--- On the wire their equivalent representation takes up
--- 24 + 'length' bytes with format:
--- 8 byte Address, 8 byte Time, 8 byte Length, Payload
-data ExtendedPoint = ExtendedPoint { extendedAddress :: Address
-                                   , extendedTime    :: TimeStamp
-                                   , extendedPayload :: ByteString }
-  deriving (Show, Eq)
-
-
 -- Result ----------------------------------------------------------------------
 
 -- | A resumption producer that yields @a@ and might return a continuation that can be

--- a/marquise.cabal
+++ b/marquise.cabal
@@ -68,7 +68,7 @@ library
                      cryptohash,
                      zeromq4-haskell,
                      time,
-                     vaultaire-common >= 2.6.0
+                     vaultaire-common >= 2.8.3
 
   ghc-options:       -O2
                      -threaded
@@ -91,7 +91,7 @@ executable marquised
                      unix,
                      async,
                      containers,
-                     vaultaire-common >= 2.5.0,
+                     vaultaire-common >= 2.8.3,
                      marquise
 
   ghc-options:       -O2
@@ -116,11 +116,11 @@ executable data
                      text,
                      attoparsec,
                      unordered-containers,
-                     vaultaire-common >= 2.5.0,
                      time,
                      old-locale,
                      data-binary-ieee754,
                      packer,
+                     vaultaire-common >= 2.8.3,
                      marquise
 
   ghc-options:       -O2
@@ -162,7 +162,7 @@ test-suite           client-test
                      hspec,
                      bytestring,
                      pipes,
-                     vaultaire-common,
+                     vaultaire-common >= 2.8.3,
                      marquise
 
   ghc-options:       -O2


### PR DESCRIPTION
....we still export it, so existing uses should be fine.