### PR TITLE
Break up decodeSimple and expose a function to decode a point outside a ...

### DIFF
--- a/lib/Marquise/Client.hs
+++ b/lib/Marquise/Client.hs
@@ -35,6 +35,7 @@ module Marquise.Client (
     , readSimplePoints
     , decodeExtended
     , decodeSimple
+    , decodeSimple'
 
     -- * Types
     , SourceDict

--- a/marquise.cabal
+++ b/marquise.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                marquise
-version:             4.0.1
+version:             4.1.0
 license-file:        LICENCE
 synopsis:            Client library for Vaultaire
 description:         Marquise is a collection of a library and two executables for use with Vaultaire.


### PR DESCRIPTION
...Pipe

Needed because the Pipe is insufficiently flexible for me to avoid code
duplication when decoding things from non-Marquise.Client sources.